### PR TITLE
Indexer with postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /target
 /test-times.txt
 /tmp
+.sqlx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,6 +3475,7 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "dotenvy",
@@ -3559,6 +3560,7 @@ dependencies = [
  "bitflags 2.4.1",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -3600,6 +3602,7 @@ dependencies = [
  "base64 0.21.6",
  "bitflags 2.4.1",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -3636,6 +3639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bip39"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,6 +2418,7 @@ dependencies = [
  "axum-server",
  "base64 0.21.6",
  "bech32",
+ "bigdecimal",
  "bip39",
  "bitcoin",
  "boilerplate",
@@ -3473,6 +3485,7 @@ checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
 dependencies = [
  "ahash",
  "atoi",
+ "bigdecimal",
  "byteorder",
  "bytes",
  "chrono",
@@ -3557,6 +3570,7 @@ checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
  "base64 0.21.6",
+ "bigdecimal",
  "bitflags 2.4.1",
  "byteorder",
  "bytes",
@@ -3600,6 +3614,7 @@ checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
  "base64 0.21.6",
+ "bigdecimal",
  "bitflags 2.4.1",
  "byteorder",
  "chrono",
@@ -3618,6 +3633,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
+ "num-bigint",
  "once_cell",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +53,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -318,6 +337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atom_syndication"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +363,16 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atomic-write-file"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
+dependencies = [
+ "nix",
+ "rand",
+]
 
 [[package]]
 name = "audit-cache"
@@ -456,6 +494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +563,9 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -756,6 +803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +840,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +875,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -828,7 +896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -846,6 +914,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -953,6 +1030,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,7 +1120,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1077,10 +1167,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1124,6 +1223,17 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if 1.0.0",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1175,6 +1285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1298,17 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1254,6 +1381,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -1452,6 +1590,19 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "headers"
@@ -1482,6 +1633,9 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1500,6 +1654,33 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "html-escaper"
@@ -1710,6 +1891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,7 +1964,7 @@ dependencies = [
  "jsonrpc-server-utils",
  "log",
  "net2",
- "parking_lot",
+ "parking_lot 0.11.2",
  "unicase",
 ]
 
@@ -1810,12 +2000,21 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
@@ -1826,6 +2025,17 @@ dependencies = [
  "bitflags 2.4.1",
  "libc",
  "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1861,6 +2071,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -2021,12 +2241,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2050,6 +2298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2198,6 +2447,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha3",
+ "sqlx",
  "sysinfo",
  "tempfile",
  "test-bitcoincore-rpc",
@@ -2259,7 +2509,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -2277,12 +2537,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.4.1",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2332,6 +2620,27 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.0.1",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -2657,6 +2966,26 @@ dependencies = [
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3043,6 +3372,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3088,6 +3427,241 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+dependencies = [
+ "itertools 0.12.1",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
+dependencies = [
+ "ahash",
+ "atoi",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "dotenvy",
+ "either",
+ "event-listener 2.5.3",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "rustls 0.21.10",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
+dependencies = [
+ "atomic-write-file",
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
+dependencies = [
+ "atoi",
+ "base64 0.21.6",
+ "bitflags 2.4.1",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
+dependencies = [
+ "atoi",
+ "base64 0.21.6",
+ "bitflags 2.4.1",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "strsim"
@@ -3466,7 +4040,19 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3521,6 +4107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,6 +4123,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unindent"
@@ -3566,6 +4164,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -3703,6 +4307,12 @@ name = "webpki-roots"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 
 [[package]]
 name = "winapi"
@@ -3993,6 +4603,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.4.0", features = ["compression-br", "compression-gzip", "cors", "set-header"] }
 
 # tokio + rustls
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres"] }
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "any", "postgres", "chrono"] }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.4.0", features = ["compression-br", "compression-gzip", "cors", "set-header"] }
 
 # tokio + rustls
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "any", "postgres", "chrono", "bigdecimal"] }
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "any", "postgres", "chrono", "bigdecimal", "json"] }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ axum = { version = "0.6.1", features = ["headers", "http2"] }
 axum-server = "0.5.0"
 base64 = "0.21.0"
 bech32 = "0.9.1"
+bigdecimal = "0.3"
 bip39 = "2.0.0"
 bitcoin = { version = "0.30.1", features = ["rand"] }
 boilerplate = { version = "1.0.0", features = ["axum"] }
@@ -68,7 +69,7 @@ tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.4.0", features = ["compression-br", "compression-gzip", "cors", "set-header"] }
 
 # tokio + rustls
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "any", "postgres", "chrono"] }
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "any", "postgres", "chrono", "bigdecimal"] }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ axum = { version = "0.6.1", features = ["headers", "http2"] }
 axum-server = "0.5.0"
 base64 = "0.21.0"
 bech32 = "0.9.1"
-bigdecimal = "0.3"
+bigdecimal = {version = "0.3", features = ["serde"] }
 bip39 = "2.0.0"
 bitcoin = { version = "0.30.1", features = ["rand"] }
 boilerplate = { version = "1.0.0", features = ["axum"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ tokio-stream = "0.1.9"
 tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.4.0", features = ["compression-br", "compression-gzip", "cors", "set-header"] }
 
+# tokio + rustls
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres"] }
+
 [dev-dependencies]
 criterion = "0.5.1"
 executable-path = "1.0.0"

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -48,13 +48,12 @@ impl Chain {
   }
 
   pub(crate) fn first_rune_height(self) -> u32 {
-    SUBSIDY_HALVING_INTERVAL
-      * match self {
-        Self::Mainnet => 4,
-        Self::Regtest => 0,
-        Self::Signet => 0,
-        Self::Testnet => 12,
-      }
+    match self {
+      Self::Mainnet => 819863,
+      Self::Regtest => 0,
+      Self::Signet => 0,
+      Self::Testnet => 2538554,
+    }
   }
 
   pub(crate) fn jubilee_height(self) -> u32 {

--- a/src/index.rs
+++ b/src/index.rs
@@ -23,7 +23,7 @@ use {
     ReadOnlyTable, ReadableMultimapTable, ReadableTable, RepairSession, StorageError, Table,
     TableDefinition, TableHandle, TableStats, WriteTransaction,
   },
-  sqlx::postgres::{PgPool, PgPoolOptions, PgRow},
+  sqlx::postgres::{PgPool, PgPoolOptions},
   std::env,
   std::{
     collections::HashMap,

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -400,7 +400,7 @@ pub(crate) struct TxInput {
   pub(crate) prevout_tx_id: Option<String>,
   pub(crate) prevout: i32,
   pub(crate) script_sig: Vec<u8>,
-  pub(crate) sequence: i32,
+  pub(crate) sequence: Option<String>,
   pub(crate) witness: Option<Vec<u8>>,
 }
 
@@ -409,7 +409,7 @@ impl TxInput {
     let prevout_tx_id = Some(txin.previous_output.txid.to_string());
     let prevout = txin.previous_output.vout as i32;
     let script_sig = txin.script_sig.to_bytes();
-    let sequence = txin.sequence.to_consensus_u32() as i32;
+    let sequence = Some(txin.sequence.to_string());
     let witness = None;
     // Serialize witness data if present
     // let witness = if !txin.witness.is_empty() {
@@ -432,6 +432,27 @@ impl TxInput {
       script_sig,
       sequence,
       witness,
+    }
+  }
+}
+
+#[derive(Serialize, Deserialize, FromRow)]
+pub(crate) struct TxOutput {
+  pub(crate) tx_id: String,
+  pub(crate) n: i32,
+  pub(crate) value: i64,
+  pub(crate) script_pubkey: Vec<u8>,
+  pub(crate) spent: bool,
+}
+
+impl TxOutput {
+  pub fn from_txout(txout: &TxOut, tx_id: &Txid, n: i32) -> TxOutput {
+    TxOutput {
+      tx_id: tx_id.to_string(),
+      n,
+      value: txout.value as i64,
+      script_pubkey: txout.script_pubkey.clone().into_bytes(),
+      spent: false,
     }
   }
 }

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -470,7 +470,7 @@ impl TxOutput {
 pub(crate) struct RuneBalance {
   pub(crate) rune_id: String,
   pub(crate) address: String,
-  pub(crate) rune_amount: Option<BigDecimal>,
+  pub(crate) rune_amount: BigDecimal,
 }
 
 #[derive(Clone, Serialize, Deserialize, FromRow)]
@@ -478,8 +478,8 @@ pub(crate) struct OutpointBalance {
   pub(crate) tx_id: String,
   pub(crate) vout: i32,
   pub(crate) address: String,
-  pub(crate) rune_id: Option<String>,
-  pub(crate) rune_amount: Option<BigDecimal>,
+  pub(crate) rune_id: String,
+  pub(crate) rune_amount: BigDecimal,
   pub(crate) burn: bool,
   pub(crate) spent: bool,
   pub(crate) value: i64,

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -1,8 +1,4 @@
-use {
-  super::*,
-  bigdecimal::{BigDecimal, FromPrimitive},
-  sqlx::FromRow,
-};
+use {super::*, bigdecimal::BigDecimal, sqlx::FromRow};
 
 pub(crate) trait Entry: Sized {
   type Value;
@@ -447,6 +443,7 @@ pub(crate) struct TxOutput {
   pub(crate) value: i64,
   pub(crate) script_pubkey: Vec<u8>,
   pub(crate) is_op_return: bool,
+  pub(crate) op_return_data: Option<serde_json::Value>,
 }
 
 impl TxOutput {
@@ -462,6 +459,7 @@ impl TxOutput {
       value: txout.value as i64,
       script_pubkey: txout.script_pubkey.clone().into_bytes(),
       is_op_return,
+      op_return_data: None,
     }
   }
 }

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -57,8 +57,10 @@ impl<'index> Updater<'_> {
     let mut wtx = self.index.begin_write()?;
     let starting_height = u32::try_from(self.index.client.get_block_count()?).unwrap() + 1;
 
-    if self.height == 0 {
-      self.height = self.index.options.first_rune_height() - 1;
+    let first_rune_height = self.index.options.first_rune_height();
+    log::info!("first_rune_height: {}", first_rune_height);
+    if first_rune_height > 0 && self.height == 0 {
+      self.height = first_rune_height - 1;
     }
 
     wtx
@@ -609,6 +611,7 @@ impl<'index> Updater<'_> {
         timestamp: block.header.time,
         transaction_id_to_rune: &mut transaction_id_to_rune,
         updates: HashMap::new(),
+        index: self.index,
       };
 
       for (i, (tx, txid)) in block.txdata.iter().enumerate() {

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -57,6 +57,10 @@ impl<'index> Updater<'_> {
     let mut wtx = self.index.begin_write()?;
     let starting_height = u32::try_from(self.index.client.get_block_count()?).unwrap() + 1;
 
+    if self.height == 0 {
+      self.height = self.index.options.first_rune_height() - 1;
+    }
+
     wtx
       .open_table(WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP)?
       .insert(

--- a/src/index/updater/rune_updater.rs
+++ b/src/index/updater/rune_updater.rs
@@ -5,6 +5,7 @@ use {
     runes::{varint, Edict, Runestone, CLAIM_BIT},
   },
   sqlx::{Pool, Postgres},
+  std::ops::Deref,
 };
 
 fn claim(id: u128) -> Option<u128> {
@@ -428,14 +429,16 @@ impl<'a, 'db, 'tx, 'index> RuneUpdater<'a, 'db, 'tx, 'index> {
     }
 
     if let Some(pg_pool) = &self.index.pg_pool {
-      Runtime::new()?.block_on(async {
-        if tx_inputs.len() > 0 {
-          let _ = self.pg_insert_tx_inputs(pg_pool, tx_inputs).await;
-        }
-        if tx_outputs.len() > 0 {
-          let _ = self.pg_insert_tx_outputs(pg_pool, tx_outputs).await;
-        }
-      });
+      if let Some(runtime) = &self.index.runtime {
+        runtime.block_on(async {
+          if tx_inputs.len() > 0 {
+            let _ = self.pg_insert_tx_inputs(pg_pool, tx_inputs).await;
+          }
+          if tx_outputs.len() > 0 {
+            let _ = self.pg_insert_tx_outputs(pg_pool, tx_outputs).await;
+          }
+        });
+      }
     }
     Ok(())
   }

--- a/src/options.rs
+++ b/src/options.rs
@@ -104,7 +104,7 @@ impl Options {
   }
 
   pub(crate) fn index_runes(&self) -> bool {
-    self.index_runes && self.chain() != Chain::Mainnet
+    self.index_runes
   }
 
   pub(crate) fn rpc_url(&self, wallet_name: Option<String>) -> String {

--- a/src/runes/edict.rs
+++ b/src/runes/edict.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Default, Serialize, Debug, PartialEq, Copy, Clone)]
+#[derive(Default, Deserialize, Serialize, Debug, PartialEq, Copy, Clone)]
 pub struct Edict {
   pub id: u128,
   pub amount: u128,

--- a/src/runes/etching.rs
+++ b/src/runes/etching.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Default, Serialize, Debug, PartialEq, Copy, Clone)]
+#[derive(Default, Deserialize, Serialize, Debug, PartialEq, Copy, Clone)]
 pub struct Etching {
   pub divisibility: u8,
   pub mint: Option<Mint>,

--- a/src/runes/mint.rs
+++ b/src/runes/mint.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Default, Serialize, Debug, PartialEq, Copy, Clone)]
+#[derive(Default, Deserialize, Serialize, Debug, PartialEq, Copy, Clone)]
 pub struct Mint {
   pub deadline: Option<u32>,
   pub limit: Option<u128>,

--- a/src/runes/rune.rs
+++ b/src/runes/rune.rs
@@ -36,33 +36,19 @@ impl Rune {
   ];
 
   pub(crate) fn minimum_at_height(chain: Chain, height: Height) -> Self {
-    let offset = height.0.saturating_add(1);
+    let length = 13u32
+      .saturating_sub(height.0 / (DIFFCHANGE_INTERVAL * 2))
+      .max(1);
 
-    const INTERVAL: u32 = SUBSIDY_HALVING_INTERVAL / 12;
-
-    let start = chain.first_rune_height();
-
-    let end = start + SUBSIDY_HALVING_INTERVAL;
-
-    if offset < start {
-      return Rune(Self::STEPS[12]);
+    let mut rune = 0u128;
+    for i in 0..length {
+      if i > 0 {
+        rune += 1;
+      }
+      rune *= 26;
     }
 
-    if offset >= end {
-      return Rune(0);
-    }
-
-    let progress = offset.saturating_sub(start);
-
-    let length = 12u32.saturating_sub(progress / INTERVAL);
-
-    let end = Self::STEPS[usize::try_from(length - 1).unwrap()];
-
-    let start = Self::STEPS[usize::try_from(length).unwrap()];
-
-    let remainder = u128::from(progress % INTERVAL);
-
-    Rune(start - ((start - end) * remainder / u128::from(INTERVAL)))
+    Rune(rune)
   }
 
   pub(crate) fn is_reserved(self) -> bool {

--- a/src/runes/runestone.rs
+++ b/src/runes/runestone.rs
@@ -2,7 +2,7 @@ use super::*;
 
 const MAX_SPACERS: u32 = 0b00000111_11111111_11111111_11111111;
 
-#[derive(Default, Serialize, Debug, PartialEq)]
+#[derive(Clone, Deserialize, Default, Serialize, Debug, PartialEq)]
 pub struct Runestone {
   pub edicts: Vec<Edict>,
   pub etching: Option<Etching>,

--- a/src/runes/runestone.rs
+++ b/src/runes/runestone.rs
@@ -61,14 +61,6 @@ impl Runestone {
 
     let Message { mut fields, edicts } = Message::from_integers(&integers);
 
-    let deadline = Tag::Deadline
-      .take(&mut fields)
-      .and_then(|deadline| u32::try_from(deadline).ok());
-
-    let default_output = Tag::DefaultOutput
-      .take(&mut fields)
-      .and_then(|default| u32::try_from(default).ok());
-
     let divisibility = Tag::Divisibility
       .take(&mut fields)
       .and_then(|divisibility| u8::try_from(divisibility).ok())
@@ -81,12 +73,6 @@ impl Runestone {
 
     let rune = Tag::Rune.take(&mut fields).map(Rune);
 
-    let spacers = Tag::Spacers
-      .take(&mut fields)
-      .and_then(|spacers| u32::try_from(spacers).ok())
-      .and_then(|spacers| (spacers <= MAX_SPACERS).then_some(spacers))
-      .unwrap_or_default();
-
     let symbol = Tag::Symbol
       .take(&mut fields)
       .and_then(|symbol| u32::try_from(symbol).ok())
@@ -96,20 +82,18 @@ impl Runestone {
       .take(&mut fields)
       .and_then(|term| u32::try_from(term).ok());
 
-    let mut flags = Tag::Flags.take(&mut fields).unwrap_or_default();
+    let etch = rune.is_some();
 
-    let etch = Flag::Etch.take(&mut flags);
-
-    let mint = Flag::Mint.take(&mut flags);
+    let mint = term.is_some() || limit.is_some();
 
     let etching = if etch {
       Some(Etching {
         divisibility,
         rune,
-        spacers,
+        spacers: 0,
         symbol,
         mint: mint.then_some(Mint {
-          deadline,
+          deadline: None,
           limit,
           term,
         }),
@@ -119,8 +103,8 @@ impl Runestone {
     };
 
     Ok(Some(Self {
-      burn: flags != 0 || fields.keys().any(|tag| tag % 2 == 0),
-      default_output,
+      burn: fields.keys().any(|tag| tag % 2 == 0),
+      default_output: None,
       edicts,
       etching,
     }))

--- a/src/runes/tag.rs
+++ b/src/runes/tag.rs
@@ -3,18 +3,18 @@ use super::*;
 #[derive(Copy, Clone, Debug)]
 pub(super) enum Tag {
   Body = 0,
-  Flags = 2,
-  Rune = 4,
-  Limit = 6,
-  Term = 8,
+  Flags = 252,
+  Rune = 2,
+  Limit = 4,
+  Term = 6,
   Deadline = 10,
   DefaultOutput = 12,
   #[allow(unused)]
   Burn = 254,
 
   Divisibility = 1,
-  Spacers = 3,
-  Symbol = 5,
+  Spacers = 253,
+  Symbol = 3,
   #[allow(unused)]
   Nop = 255,
 }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -60,9 +60,10 @@ impl Subcommand {
       Self::Runes => runes::run(options),
       Self::Server(server) => {
         let index = Arc::new(Index::open(&options)?);
+        let runtime = Arc::new(Runtime::new()?);
         let handle = axum_server::Handle::new();
         LISTENERS.lock().unwrap().push(handle.clone());
-        server.run(options, index, handle)
+        server.run(options, runtime, index, handle)
       }
       Self::Subsidy(subsidy) => subsidy.run(),
       Self::Supply => supply::run(),

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -35,6 +35,8 @@ use {
     caches::DirCache,
     AcmeConfig,
   },
+  sqlx::postgres::PgPoolOptions,
+  std::env,
   std::{cmp::Ordering, io::Read, str, sync::Arc},
   tokio_stream::StreamExt,
   tower_http::{
@@ -186,6 +188,28 @@ impl Server {
   pub fn run(self, options: Options, index: Arc<Index>, handle: Handle) -> SubcommandResult {
     Runtime::new()?.block_on(async {
       let index_clone = index.clone();
+
+      if options.index_runes {
+        let db_connection_str = match env::var("DATABASE_URL") {
+          Ok(url) => url,
+          Err(error) => {
+            log::warn!("Failed to fetch DATABASE_URL in .env: {error}");
+            "".to_string()
+          }
+        };
+
+        if !db_connection_str.is_empty() {
+          match PgPoolOptions::new().connect(&db_connection_str).await {
+            Ok(pg_pool) => {
+              index_clone.set_pg_pool(pg_pool);
+              log::info!("Set up Postgres connection pool");
+            }
+            Err(error) => {
+              log::warn!("Can't connect to Postgres database: {error}");
+            }
+          }
+        }
+      }
 
       let index_thread = thread::spawn(move || loop {
         if SHUTTING_DOWN.load(atomic::Ordering::Relaxed) {

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -4,6 +4,7 @@ use {
   bitcoincore_rpc::{Auth, Client, RpcApi},
   ord::{parse_ord_server_args, Index},
   reqwest::blocking::Response,
+  tokio::runtime::Runtime,
 };
 
 pub(crate) struct TestServer {
@@ -61,9 +62,14 @@ impl TestServer {
     let ord_server_handle = Handle::new();
 
     {
+      let runtime = Arc::new(Runtime::new().unwrap());
       let index = index.clone();
       let ord_server_handle = ord_server_handle.clone();
-      thread::spawn(|| server.run(options, index, ord_server_handle).unwrap());
+      thread::spawn(|| {
+        server
+          .run(options, runtime, index, ord_server_handle)
+          .unwrap()
+      });
     }
 
     for i in 0.. {


### PR DESCRIPTION
## Summary

Support to index runes data into PostgreSQL DB.

* use the crate [sqlx](https://docs.rs/crate/sqlx/latest)
* add `init_pg_pool` in `index.rs`
* add entry into `entry.rs` for the tables
  - runes
  - runes_balances
  - tx_outputs
  - outpoint_balances
  - tx_inputs
 * add the index logic, and operations of the pg table into `rune_updater.rs`
 

## Test Plan

For Testnet, please use the pg sql and db url in the [notion](https://www.notion.so/octopusnetwork/Index-Rune-to-PgSQL-3719451e22dc4d1ba06127bc1a8f1279?pvs=4) 

0. run `bitcoind` in `testnet`
1. set env: `set +H;export DATABASE_URL=<>;cargo sqlx prepare;`
2. build: `cargo build --release`
3. run index with info log: 
    ```bash
    RUST_LOG=info ./target/release/ord \
    --bitcoin-data-dir <bitcoindata> \
    --bitcoin-rpc-pass <bitcoinrpcuser> \
    --bitcoin-rpc-user <bitcoinrpcpwd> \
    --data-dir <index-data> \
    --rpc-url <bitcoinrpcurl> \
    --cookie-file <bitcoin.cookie> \
    --index-runes -n -t \
    server --http --http-port 8080
    ```
